### PR TITLE
Removes outdated comments, omits "cost" wording

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -3,7 +3,7 @@
   "category_label": "Models",
   "branding": {
     "image_uri": "https://wwwstatic-a.lookercdn.com/blocks/logos/aws.png",
-    "tagline": "Fine-tune your Redshift deployment with a comprehensive view of performance and cost."
+    "tagline": "Fine-tune your Redshift deployment with a comprehensive view of performance and query analysis."
   },
 
   "constants": {

--- a/redshift_plan_steps_core.view.lkml
+++ b/redshift_plan_steps_core.view.lkml
@@ -5,7 +5,6 @@ view: redshift_plan_steps {
 }
 
 view: redshift_plan_steps_core {
-  #description: "Steps from the query planner for recent queries to Redshift"
   derived_table: {
     datagroup_trigger: nightly
     distribution: "query"
@@ -49,7 +48,6 @@ view: redshift_plan_steps_core {
           ON redshift_plan_steps.query = x.query AND redshift_plan_steps.nodeid = x.parentid
         ORDER BY 1,3
     ;;
-    #TODO?: Currently not extracting the sequential scan column, but I'm not sure if this is useful to extract. What's more useful as far as I can tell are the fields in the filter (operation argument)
 
     }
 
@@ -75,7 +73,6 @@ view: redshift_plan_steps_core {
 
     dimension: query_step {
       sql: ${query}||'.'||${step} ;;
-      #primary_key: yes #Unfortunately not, because all CTE plans are labeled as step 0
       hidden: yes
     }
 
@@ -141,7 +138,6 @@ view: redshift_plan_steps_core {
     }
 
     dimension: network_distribution_bytes {
-      #TODO: Multiply by number of nodes if BCAST?
       description: "Bytes from inner and outer children needing to be distributed or broadcast. (For broadcast, this value does not multiply by the number of nodes broadcast to.)"
       sql: CASE
               WHEN ${network_distribution_type} ILIKE '%INNER%' THEN ${inner_child.bytes}

--- a/redshift_queries_avg_core.view.lkml
+++ b/redshift_queries_avg_core.view.lkml
@@ -5,9 +5,6 @@ view: redshift_queries_avg {
 }
 
 view: redshift_queries_avg_core {
-# Added to generate histogram of average query runtimes
-# If necessary, uncomment the line below to include explore_source.
-# include: "redshift_admin.model.lkml"
     derived_table: {
       explore_source: redshift_queries {
         column: query {}

--- a/redshift_queries_core.view.lkml
+++ b/redshift_queries_core.view.lkml
@@ -257,12 +257,6 @@ view: redshift_queries_core {
       value_format_name: decimal_1
     }
 
-    #   measure: total_time_elapsed {
-    #     type: sum
-    #     description: "Sum of time from another table, for comparison"
-    #     sql: ${time_elapsed}  ;;
-    #   }
-
     measure: time_executing_per_query {
       hidden: yes
       type: number

--- a/redshift_query_execution_core.view.lkml
+++ b/redshift_query_execution_core.view.lkml
@@ -5,8 +5,7 @@ view: redshift_query_execution {
 }
 
 view: redshift_query_execution_core {
-  #For recent queries based on redshift_queries
-  #description: "Steps from the query planner for recent queries to Redshift"
+
   derived_table: {
     datagroup_trigger: nightly
     distribution: "query"
@@ -46,8 +45,6 @@ view: redshift_query_execution_core {
         GROUP BY query, seg, step, label
       ;;
   }
-  # or svl_query_report to not aggregate over slices under each step
-  #using group by because sometimes steps are duplicated.seems to be when some slices are diskbased, others not
 
   # DIMENSIONS #
 
@@ -280,7 +277,6 @@ view: redshift_query_execution_core {
     description: "Aggregates multiple n log(n) time-complexity sortings by comparing them to one sort that would have approximately the same time complexity"
     #http://cs.stackexchange.com/questions/44944/n-log-n-c-what-are-some-good-approximations-of-this
     #1st answer with an added first order Newton approximation
-    # https://docs.google.com/a/looker.com/spreadsheets/d/1mT3rddVH61KQzeULjfWVtnkweZ_gsCmeMhOFB8T1elo/edit?usp=sharing
     sql:CASE WHEN ${total_O_rows_sorted}<2 THEN ${total_O_rows_sorted}
           ELSE LN(2)*${total_O_rows_sorted}*(1+LN(ln((${total_O_rows_sorted}/LN(${total_O_rows_sorted})*LN(2)))/LN(2))/LN(2)/(LN((${total_O_rows_sorted}/LN(${total_O_rows_sorted})*LN(2)))/LN(2)))/LN(${total_O_rows_sorted})
           END;;

--- a/redshift_tables_core.view.lkml
+++ b/redshift_tables_core.view.lkml
@@ -8,7 +8,7 @@ view: redshift_tables_core {
   derived_table: {
     datagroup_trigger: nightly
     distribution_style: all
-    indexes: ["table_id","table"] # "indexes" translates to an interleaved sort key for Redshift
+    indexes: ["table_id","table"]
     # http://docs.aws.amazon.com/redshift/latest/dg/r_SVV_TABLE_INFO.html
     sql: select
         "database"::varchar,


### PR DESCRIPTION
Ran into confusion w/ the BigQuery & Snowflake "Cost" blocks. The redshift admin block only includes "Query cost". 

From the Redshift docs, this "Cost" is defined as:
>The relative cost of the operation. Cost is a measure that compares the relative execution times of the steps within a plan. Cost does not provide any precise information about actual execution times or memory consumption, nor does it provide a meaningful comparison between execution plans. It does give you an indication of which operations in a query are consuming the most resources.

source: https://docs.aws.amazon.com/redshift/latest/dg/c-the-query-plan.html